### PR TITLE
Bump extension to v0.1.2

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,7 +1,7 @@
 id = "vue"
 name = "Vue"
 description = "Vue support."
-version = "0.1.1"
+version = "0.1.2"
 schema_version = 1
 authors = ["Piotr Osiewicz <piotr@zed.dev>"]
 repository = "https://github.com/zed-extensions/vue"


### PR DESCRIPTION
This is a no-op change beyond updating to the new repository.