### PR TITLE
Pug template syntax highlighting in component files

### DIFF
--- a/languages/vue/injections.scm
+++ b/languages/vue/injections.scm
@@ -79,3 +79,15 @@
     (#not-any-of? @_attr_name "lang")
     (#set! language "css")
 )
+
+; <template lang="pug">
+((template_element
+  (start_tag
+    (attribute
+      (attribute_name) @_lang
+      (quoted_attribute_value
+        (attribute_value) @_pug)))
+  (text) @content)
+  (#eq? @_lang "lang")
+  (#eq? @_pug "pug")
+  (#set! language "pug"))


### PR DESCRIPTION
Enables the Pug syntax highlighting extension to be used when a `<template lang="pug">` tag is present in a component