### PR TITLE
Allow PnP users to specify TypeScript SDK location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 #
 
 *.wasm
+grammars/
 
 #
 # Rust

--- a/README.md
+++ b/README.md
@@ -10,13 +10,12 @@ To develop this extension, see the [Developing Extensions](https://zed.dev/docs/
 
 ### Specifying location of TypeScript SDK
 
-By default, this extension assumes that you are working in a project with a `node_modules`
-directory, and searches for the TypeScript SDK inside that directory.
+By default, this extension assumes that you are working in a project with a `node_modules` directory, and searches for
+the TypeScript SDK inside that directory.
 
-This may not always be true; for example, when working in a project that uses Yarn PnP, there is
-no `node_modules`. For editor support, the [documented](https://yarnpkg.com/getting-started/editor-sdks)
-approach is to run something like `yarn dlx @yarnpkg/sdks`. In that case, you can provide the following
-initialization options in your Zed settings:
+This may not always be true; for example, when working in a project that uses Yarn PnP, there is no `node_modules`. For
+editor support, the [documented](https://yarnpkg.com/getting-started/editor-sdks) approach is to run something like
+`yarn dlx @yarnpkg/sdks`. In that case, you can provide the following initialization options in your Zed settings:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -5,3 +5,29 @@ A [Vue](https://vuejs.org/) extension for [Zed](https://zed.dev).
 ## Development
 
 To develop this extension, see the [Developing Extensions](https://zed.dev/docs/extensions/developing-extensions) section of the Zed docs.
+
+## Initialization Options
+
+### Specifying location of TypeScript SDK
+
+By default, this extension assumes that you are working in a project with a `node_modules`
+directory, and searches for the TypeScript SDK inside that directory.
+
+This may not always be true; for example, when working in a project that uses Yarn PnP, there is
+no `node_modules`. For editor support, the [documented](https://yarnpkg.com/getting-started/editor-sdks)
+approach is to run something like `yarn dlx @yarnpkg/sdks`. In that case, you can provide the following
+initialization options in your Zed settings:
+
+```json
+{
+  "lsp": {
+    "vue": {
+      "initialization_options": {
+        "typescript": {
+          "tsdk": ".yarn/sdks/typescript/lib"
+        }
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
As described in #8, there is no `node_modules` directory when working in a Yarn PnP project. One of the assumptions this extension makes is that the TypeScript SDK is located in `node_modules`.

This patch allows users of this extension to specify the `tsdk` location via the LSP `initialization_options`, if required. By default, the existing behavior is retained.

Also closes #9.

(Note, I don't think it fully fixes the issues in #8, but this is maybe step 1?)