### PR TITLE
Add workaround for leading slash in Windows paths

### DIFF
--- a/src/vue.rs
+++ b/src/vue.rs
@@ -117,8 +117,7 @@ impl VueExtension {
             println!("typescript already installed");
         }
 
-        self.typescript_tsdk_path = env::current_dir()
-            .unwrap()
+        self.typescript_tsdk_path = zed_ext::sanitize_windows_path(env::current_dir().unwrap())
             .join(TYPESCRIPT_TSDK_PATH)
             .to_string_lossy()
             .to_string();
@@ -144,8 +143,7 @@ impl zed::Extension for VueExtension {
         Ok(zed::Command {
             command: zed::node_binary_path()?,
             args: vec![
-                env::current_dir()
-                    .unwrap()
+                zed_ext::sanitize_windows_path(env::current_dir().unwrap())
                     .join(&server_path)
                     .to_string_lossy()
                     .to_string(),
@@ -214,3 +212,25 @@ impl zed::Extension for VueExtension {
 }
 
 zed::register_extension!(VueExtension);
+
+/// Extensions to the Zed extension API that have not yet stabilized.
+mod zed_ext {
+    /// Sanitizes the given path to remove the leading `/` on Windows.
+    ///
+    /// On macOS and Linux this is a no-op.
+    ///
+    /// This is a workaround for https://github.com/bytecodealliance/wasmtime/issues/10415.
+    pub fn sanitize_windows_path(path: std::path::PathBuf) -> std::path::PathBuf {
+        use zed_extension_api::{current_platform, Os};
+
+        let (os, _arch) = current_platform();
+        match os {
+            Os::Mac | Os::Linux => path,
+            Os::Windows => path
+                .to_string_lossy()
+                .to_string()
+                .trim_start_matches('/')
+                .into(),
+        }
+    }
+}


### PR DESCRIPTION
This is related to zed-industries/zed#20559, and is based on the instructions given by @maxdeviant in that issue.

See also zed-extensions/astro#5 for a reference implementation.

This is the error I'm getting, which this PR should hopefully fix:
```
Language server error: vue-language-server

Request initialize failed with message: Can't find typescript.js or tsserverlibrary.js in "/C:\\Users\\user\\AppData\\Local\\Zed\\extensions\\work\\vue/node_modules/typescript/lib"
-- stderr--
```