### PR TITLE
Improve tag auto-indent

### DIFF
--- a/languages/vue/brackets.scm
+++ b/languages/vue/brackets.scm
@@ -2,3 +2,5 @@
 ("\"" @open "\"" @close)
 ("<" @open "/>" @close)
 ("</" @open ">" @close)
+
+((element (start_tag) @open [(end_tag) (erroneous_end_tag)] @close) (#set! newline.only))

--- a/languages/vue/indents.scm
+++ b/languages/vue/indents.scm
@@ -1,0 +1,3 @@
+(element
+  (start_tag) @start
+  [(end_tag) (erroneous_end_tag)]? @end) @indent


### PR DESCRIPTION
Improves auto-indent and newline.only queries. This makes it so when hitting enter between an open and closing tag like so
```html
<div>|</div>
```
The result is:
```html
<div>
    |
</div>
```
Instead of:
```html
<div>
|</div>
```

Even when the closing tag does not have the same name as the opening tag (i.e. `<div></p>` still auto-indents correctly)
