### PR TITLE
feat: add languages to ts servers plugin settings

### DIFF
--- a/src/vue.rs
+++ b/src/vue.rs
@@ -224,6 +224,7 @@ impl zed::Extension for VueExtension {
                 "plugins": [{
                     "name": "@vue/typescript-plugin",
                     "location": self.get_ts_plugin_root_path(worktree)?.unwrap_or_else(|| worktree.root_path()),
+                    "languages": ["typescript", "vue.js"],
                 }],
             }))),
             _ => Ok(None),
@@ -243,7 +244,8 @@ impl zed::Extension for VueExtension {
                         "globalPlugins": [{
                             "name": "@vue/typescript-plugin",
                             "location": self.get_ts_plugin_root_path(worktree)?.unwrap_or_else(|| worktree.root_path()),
-                            "enableForWorkspaceTypeScriptVersions": true
+                            "enableForWorkspaceTypeScriptVersions": true,
+                            "languages": ["typescript", "vue.js"],
                         }]
                     }
                 },


### PR DESCRIPTION
This will make it possible to use the Vue plugin in hybrid mode which is the [recommended way since v2 of vue language tools](https://gist.github.com/johnsoncodehk/62580d04cb86e576e0e8d6bf1cb44e73). 

**The hybrid mode setting will be deprecated in v3 of vue language tools. So current Vue extension will break when v3 becomes stable.**

This pr will make it easier to enable hybrid mode but will still need some additional settings. 
```json
// Settings to enable hybrid mode. (after this pr)
{
  "languages": {
    "Vue.js": {
      "language_servers": [
        "vtsls",
        "..."
      ]
    }
  },
  "lsp": {
    "vue-language-server": {
      "initialization_options": {
        "vue": {
          "hybridMode": true
        }
      }
    },
  },
}
```

Would be neat that in the future to be able to have the hybrid mode as default and work out of the box after you install the Vue plugin. 