### PR TITLE
Improve syntax highlighting

### DIFF
--- a/languages/vue/highlights.scm
+++ b/languages/vue/highlights.scm
@@ -1,11 +1,20 @@
-(attribute) @property
+(comment) @comment
+
+(
+    (tag_name) @tag
+    (#match? @tag "^[a-z]")
+)
+
+(
+    (tag_name) @tag @tag.component.type.constructor
+    (#match? @tag "^[A-Z]")
+)
+
+(attribute) @attribute
 (directive_attribute) @property
 (quoted_attribute_value) @string
 (interpolation) @punctuation.special
 (raw_text) @embedded
-
-((tag_name) @type
- (#match? @type "^[A-Z]"))
 
 (directive_name) @keyword
 (directive_argument) @constant
@@ -13,3 +22,12 @@
 (start_tag) @tag
 (end_tag) @tag
 (self_closing_tag) @tag
+
+"=" @operator
+
+[
+  "<"
+  ">"
+  "</"
+  "/>"
+] @punctuation.bracket


### PR DESCRIPTION
this PR aims to improve the syntax highlighting to make it more consistent with other html-like languages like svelte, jsx, and html
after:
![image](https://github.com/user-attachments/assets/5d5f024e-0560-4047-adc0-3ee6b1dc6885)
