### PR TITLE
Make autoclose HTML tags work

### DIFF
--- a/languages/vue/config.toml
+++ b/languages/vue/config.toml
@@ -8,7 +8,7 @@ brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
-    { start = "<", end = ">", close = true, newline = true, not_in = ["string", "comment"] },
+    { start = "<", end = ">", close = false, newline = true, not_in = ["string", "comment"] },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
     { start = "`", end = "`", close = true, newline = false, not_in = ["string"] },


### PR DESCRIPTION
Fixes an interaction between autoclosing a `<` `>` pair and autoclosing HTML tags.