### PR TITLE
Add support for inlay hints

### DIFF
--- a/src/vue.rs
+++ b/src/vue.rs
@@ -224,10 +224,10 @@ impl zed::Extension for VueExtension {
             .and_then(|settings| settings.settings)
             .unwrap_or_else(|| {
                 json!({
-                    "vue.inlayHints.inlineHandlerLeading": false,
-                    "vue.inlayHints.missingProps": false,
-                    "vue.inlayHints.optionsWrapper": false,
-                    "vue.inlayHints.vBindShorthand": false,
+                    "vue.inlayHints.inlineHandlerLeading": true,
+                    "vue.inlayHints.missingProps": true,
+                    "vue.inlayHints.optionsWrapper": true,
+                    "vue.inlayHints.vBindShorthand": true,
                 })
             });
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/7086

This adds support for inlay hints by responding to the `workspace/configuration` request.

```json
{
  "lsp": {
    "vue": {
      "settings": {
        "vue.inlayHints.inlineHandlerLeading": true,
        "vue.inlayHints.missingProps": true,
        "vue.inlayHints.optionsWrapper": true,
        "vue.inlayHints.vBindShorthand": true
      }
    }
  }
}
```