### PR TITLE
Use latest @vue/language-server version

### DIFF
--- a/src/vue.rs
+++ b/src/vue.rs
@@ -205,7 +205,7 @@ impl zed::Extension for VueExtension {
                 "plugins": [{
                     "name": "@vue/typescript-plugin",
                     "location": self.get_ts_plugin_root_path(worktree)?.unwrap_or_else(|| worktree.root_path()),
-                    "languages": ["typescript", "vue"],
+                    "languages": ["typescript", "vue.js"],
                 }],
             }))),
             _ => Ok(None),
@@ -226,7 +226,7 @@ impl zed::Extension for VueExtension {
                             "name": "@vue/typescript-plugin",
                             "location": self.get_ts_plugin_root_path(worktree)?.unwrap_or_else(|| worktree.root_path()),
                             "enableForWorkspaceTypeScriptVersions": true,
-                            "languages": ["typescript", "vue"],
+                            "languages": ["typescript", "vue.js"],
                         }]
                     }
                 },


### PR DESCRIPTION
Closes https://github.com/zed-extensions/vue/issues/48

Migration guide: https://github.com/vuejs/language-tools/discussions/5456

Related PR: https://github.com/zed-industries/zed/pull/40651

Note: Should be released after https://github.com/zed-industries/zed/pull/40651 is live on both Stable and Preview.