### PR TITLE
Revert "Use latest @vue/language-server version"

### DIFF
--- a/src/vue.rs
+++ b/src/vue.rs
@@ -14,6 +14,9 @@ const PACKAGE_NAME: &str = "@vue/language-server";
 const TYPESCRIPT_PACKAGE_NAME: &str = "typescript";
 const TS_PLUGIN_PACKAGE_NAME: &str = "@vue/typescript-plugin";
 
+/// The relative path to TypeScript's SDK.
+const TYPESCRIPT_TSDK_PATH: &str = "node_modules/typescript/lib";
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct PackageJson {
@@ -25,6 +28,7 @@ struct PackageJson {
 
 struct VueExtension {
     did_find_server: bool,
+    typescript_tsdk_path: String,
 }
 
 impl VueExtension {
@@ -48,7 +52,8 @@ impl VueExtension {
             language_server_id,
             &zed::LanguageServerInstallationStatus::CheckingForUpdate,
         );
-        let version = zed::npm_package_latest_version(PACKAGE_NAME)?;
+        // We hardcode the version to 2.2.8 since we do not support @vue/language-server 3.0 yet.
+        let version = "2.2.8".to_string();
 
         if !server_exists
             || zed::npm_package_installed_version(PACKAGE_NAME)?.as_ref() != Some(&version)
@@ -100,7 +105,7 @@ impl VueExtension {
             .typescript_exists_for_worktree(worktree)
             .unwrap_or_default()
         {
-            println!("found local TypeScript installation");
+            println!("found local TypeScript installation at '{TYPESCRIPT_TSDK_PATH}'");
             return Ok(());
         }
 
@@ -114,6 +119,12 @@ impl VueExtension {
         } else {
             println!("typescript already installed");
         }
+
+        self.typescript_tsdk_path = env::current_dir()
+            .unwrap()
+            .join(TYPESCRIPT_TSDK_PATH)
+            .to_string_lossy()
+            .to_string();
 
         Ok(())
     }
@@ -159,6 +170,7 @@ impl zed::Extension for VueExtension {
     fn new() -> Self {
         Self {
             did_find_server: false,
+            typescript_tsdk_path: TYPESCRIPT_TSDK_PATH.to_owned(),
         }
     }
 
@@ -190,7 +202,17 @@ impl zed::Extension for VueExtension {
         let initialization_options = LspSettings::for_worktree("vue", worktree)
             .ok()
             .and_then(|settings| settings.initialization_options)
-            .unwrap_or_else(|| json!({}));
+            .unwrap_or_else(|| {
+                json!({
+                    "typescript": {
+                        "tsdk": self.typescript_tsdk_path
+                    },
+                    "vue": {
+                        "hybridMode": false,
+                    }
+                })
+            });
+
         Ok(Some(initialization_options))
     }
 


### PR DESCRIPTION
Looks like while this new language server version works (hover definitions, completions for Vue code, etc), it regresses the completions for Typescript scoped part of the file. Reverting until that is figured out.