### PR TITLE
Add `:`, `@` and `-` to completion query characters

### DIFF
--- a/languages/vue/config.toml
+++ b/languages/vue/config.toml
@@ -27,7 +27,6 @@ tag_name_node_name = "tag_name"
 erroneous_close_tag_node_name = "erroneous_end_tag"
 erroneous_close_tag_name_node_name = "erroneous_end_tag_name"
 
-
 [overrides.string]
 completion_query_characters = ["-"]
 opt_into_language_servers = ["tailwindcss-language-server"]


### PR DESCRIPTION
Closes #29.
Closes #75

The current version does not trigger autocompletion, we are still using the manual trigger  ctrl space to call the autocomplete list, there is now a problem that it cannot be filtered out by :@-, which is supported in vue,

especially 
@ is used to bingding events 
 :  is used to bind props


  
---

NOTE: On my computer, it works after I install the local extension of this PR and restart Zed.
