### PR TITLE
Add `outline.scm` 

### DIFF
--- a/languages/vue/outline.scm
+++ b/languages/vue/outline.scm
@@ -4,7 +4,6 @@
 ; ========== template =========
 (template_element
   (start_tag) @name
-  (attribute (attribute_name) @attr_name (quoted_attribute_value (attribute_value) @attr_value))*
 ) @item
 
 
@@ -24,16 +23,10 @@
 
 (script_element
     (start_tag) @name
-    (raw_text) @context @item
-)
-
-(script_element
-    (end_tag) @name @item
-)
+) @item
 
 
 ; ========= style =========
 (style_element
     (start_tag) @name
-    (raw_text) @context
 ) @item


### PR DESCRIPTION
add a super simple `outline.scm`  to quick jump among  `script` `template` `style` blocks


https://github.com/user-attachments/assets/9695fdb3-7661-4a2e-a054-58c5460468f6

