### PR TITLE
Initialize CI/CD workflows

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,52 @@
+# Generated from xtask::workflows::extensions::bump_version within the Zed repository.
+# Rebuild with `cargo xtask workflows`.
+name: extensions::bump_version
+on:
+  pull_request:
+    types:
+    - labeled
+  push:
+    branches:
+    - main
+    paths-ignore:
+    - .github/**
+  workflow_dispatch: {}
+jobs:
+  determine_bump_type:
+    runs-on: namespace-profile-16x32-ubuntu-2204
+    steps:
+    - id: get-bump-type
+      name: extensions::bump_version::get_bump_type
+      run: |
+        if [ "$HAS_MAJOR_LABEL" = "true" ]; then
+            bump_type="major"
+        elif [ "$HAS_MINOR_LABEL" = "true" ]; then
+            bump_type="minor"
+        else
+            bump_type="patch"
+        fi
+        echo "bump_type=$bump_type" >> $GITHUB_OUTPUT
+      shell: bash -euxo pipefail {0}
+      env:
+        HAS_MAJOR_LABEL: |-
+          ${{ (github.event.action == 'labeled' && github.event.label.name == 'major') ||
+          (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'major')) }}
+        HAS_MINOR_LABEL: |-
+          ${{ (github.event.action == 'labeled' && github.event.label.name == 'minor') ||
+          (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'minor')) }}
+    outputs:
+      bump_type: ${{ steps.get-bump-type.outputs.bump_type }}
+  call_bump_version:
+    needs:
+    - determine_bump_type
+    if: github.event.action != 'labeled' || needs.determine_bump_type.outputs.bump_type != 'patch'
+    uses: zed-industries/zed/.github/workflows/extension_bump.yml@main
+    secrets:
+      app-id: ${{ secrets.ZED_ZIPPY_APP_ID }}
+      app-secret: ${{ secrets.ZED_ZIPPY_APP_PRIVATE_KEY }}
+    with:
+      bump-type: ${{ needs.determine_bump_type.outputs.bump_type }}
+      force-bump: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}labels
+  cancel-in-progress: true

--- a/.github/workflows/release_version.yml
+++ b/.github/workflows/release_version.yml
@@ -1,0 +1,13 @@
+# Generated from xtask::workflows::extensions::release_version within the Zed repository.
+# Rebuild with `cargo xtask workflows`.
+name: extensions::release_version
+on:
+  push:
+    tags:
+    - v**
+jobs:
+  call_release_version:
+    uses: zed-industries/zed/.github/workflows/extension_release.yml@main
+    secrets:
+      app-id: ${{ secrets.ZED_ZIPPY_APP_ID }}
+      app-secret: ${{ secrets.ZED_ZIPPY_APP_PRIVATE_KEY }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,16 @@
+# Generated from xtask::workflows::extensions::run_tests within the Zed repository.
+# Rebuild with `cargo xtask workflows`.
+name: extensions::run_tests
+on:
+  pull_request:
+    branches:
+    - '**'
+  push:
+    branches:
+    - main
+jobs:
+  call_extension_tests:
+    uses: zed-industries/zed/.github/workflows/extension_tests.yml@main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.ref_name == 'main' && github.sha || 'anysha' }}pr
+  cancel-in-progress: true


### PR DESCRIPTION
This adds the new workflows for extensions to this repository.
This will enable automated testing on PRs as well as automatically created version bumps from now on