### PR TITLE
Pin vue-language-server to v3.2.1 to avoid upstream crash

### DIFF
--- a/src/vue.rs
+++ b/src/vue.rs
@@ -11,6 +11,12 @@ use zed_extension_api::{self as zed, serde_json, Result};
 const SERVER_PATH: &str = "node_modules/@vue/language-server/bin/vue-language-server.js";
 const PACKAGE_NAME: &str = "@vue/language-server";
 
+// Pin to 3.2.1 to work around an upstream crash in @vue/language-service where
+// `meta?.props.map(...)` throws when `meta.props` is undefined.
+// See: https://github.com/vuejs/language-tools/issues/5956
+// TODO: Remove this pin once upstream publishes a fixed version.
+const PINNED_SERVER_VERSION: &str = "3.2.1";
+
 const TYPESCRIPT_PACKAGE_NAME: &str = "typescript";
 const TS_PLUGIN_PACKAGE_NAME: &str = "@vue/typescript-plugin";
 
@@ -48,7 +54,7 @@ impl VueExtension {
             language_server_id,
             &zed::LanguageServerInstallationStatus::CheckingForUpdate,
         );
-        let version = zed::npm_package_latest_version(PACKAGE_NAME)?;
+        let version = PINNED_SERVER_VERSION.to_string();
 
         if !server_exists
             || zed::npm_package_installed_version(PACKAGE_NAME)?.as_ref() != Some(&version)


### PR DESCRIPTION
## Problem

The Vue language server crashes silently in Zed when providing attribute completions. The crash originates in `@vue/language-service` at `vue-template.js:604`, where the code uses:

```js
meta?.props.map(prop => [prop.name, prop]) ?? []
```

This throws a `TypeError: Cannot read properties of undefined (reading 'map')` when `meta` exists but `meta.props` is `undefined`. The safe form would be `meta?.props?.map(...)`.

This bug was introduced upstream in [vuejs/language-tools#5888](https://github.com/vuejs/language-tools/pull/5888) and affects `@vue/language-server` versions **3.2.2+**.

**Upstream issue:** https://github.com/vuejs/language-tools/issues/5956

## Solution

Pin `@vue/language-server` to version **3.2.1** (the last known working version before the buggy change) instead of dynamically fetching the latest version via `npm_package_latest_version`.

This is a temporary workaround. Once the upstream package publishes a fix, the pin should be removed so users can receive future updates.

## Changes

- Added a `PINNED_SERVER_VERSION` constant set to `"3.2.1"` with a comment explaining the reason and linking to the upstream issue.
- Replaced `zed::npm_package_latest_version(PACKAGE_NAME)?` with `PINNED_SERVER_VERSION.to_string()` in `server_script_path`.
- Added a `TODO` comment to remove the pin once upstream is fixed.

Fixes #92