### PR TITLE
Improve buffer symbols outline

### DIFF
--- a/languages/vue/outline.scm
+++ b/languages/vue/outline.scm
@@ -7,12 +7,10 @@
 
 ; Custom elements/components (PascalCase or hyphenated) - self-closing tags
 (element
-  (start_tag
-    (tag_name) @name)) @item
+  (start_tag) @name) @item
 
 (element
-  (self_closing_tag
-    (tag_name) @name)) @item
+  (self_closing_tag) @name) @item
 
 ; ======= script ======
 (script_element


### PR DESCRIPTION
As of now, the outline for Vue files only captures `(tag_name)` for the template section elements, which means every entry just shows `div`, `section`, `img`, etc. no context about which element the user is actually looking at.

<picture>
  <source
    media="(prefers-color-scheme: dark)"
    srcset="https://github.com/user-attachments/assets/656ecbc1-9765-42f2-9287-04dcbbe92401"
  />
  <img src="https://github.com/user-attachments/assets/705043f8-1850-4349-9374-64ba322eadd6" />
</picture>

This PR changes the captures to use the full nodes instead, so the outline now shows the complete tag including attributes.

This also aligns the script and style block captures with how Svelte handles them in Zed, showing the full start tag as the outline label.

## Breaking changes?
**None** 🙌🏼 

It's purely a display improvement, it uses the same nodes but displaying more helpful context for the user.