### PR TITLE
Highlight kebab-case Vue component tags

### DIFF
--- a/languages/vue/highlights.scm
+++ b/languages/vue/highlights.scm
@@ -1,10 +1,10 @@
 (comment) @comment
 
 ((tag_name) @tag
-  (#match? @tag "^[a-z]"))
+  (#match? @tag "^[a-z][a-z0-9]*$"))
 
 ((tag_name) @tag @tag.component.type.constructor
-  (#match? @tag "^[A-Z]"))
+  (#match? @tag "(^[A-Z][A-Za-z0-9]*$)|(^[a-z][a-z0-9]*(-[a-z0-9]+)+$)"))
 
 (attribute) @attribute
 


### PR DESCRIPTION
## Summary

This updates Vue syntax highlighting so kebab-case component tags are highlighted as components.

Previously, only PascalCase tags matched the component rule, so tags like `<my-component>` fell back to regular tag highlighting.

## Changes

- keep plain lowercase HTML tags like `<div>` as regular tags
- keep PascalCase tags like `<MyComponent>` highlighted as components
- highlight kebab-case tags like `<my-component>` as components

## Verification

Tested in Zed after reloading extensions with examples like:

```vue
<MyComponent />
<my-component />
<div />
```