### PR TITLE
Improve Vue template token captures for theme consistency

### DIFF
--- a/languages/vue/highlights.scm
+++ b/languages/vue/highlights.scm
@@ -16,7 +16,11 @@
 
 (raw_text) @embedded
 
-(directive_name) @keyword.directive
+((directive_name) @punctuation.delimiter
+  (#match? @punctuation.delimiter "^[:@#]$"))
+
+((directive_name) @keyword.directive
+  (#match? @keyword.directive "^v-"))
 
 (directive_argument) @attribute
 

--- a/languages/vue/highlights.scm
+++ b/languages/vue/highlights.scm
@@ -26,7 +26,7 @@
 
 (self_closing_tag) @tag
 
-"=" @operator
+"=" @punctuation.delimiter
 
 [
   "<"

--- a/languages/vue/highlights.scm
+++ b/languages/vue/highlights.scm
@@ -32,6 +32,8 @@
 
 "=" @punctuation.delimiter
 
+":" @punctuation.delimiter
+
 [
   "<"
   ">"

--- a/languages/vue/highlights.scm
+++ b/languages/vue/highlights.scm
@@ -18,7 +18,7 @@
 
 (directive_name) @keyword.directive
 
-(directive_argument) @constant
+(directive_argument) @attribute
 
 (start_tag) @tag
 

--- a/languages/vue/highlights.scm
+++ b/languages/vue/highlights.scm
@@ -17,7 +17,7 @@
 (raw_text) @embedded
 
 ((directive_name) @punctuation.delimiter
-  (#match? @punctuation.delimiter "^[:@#]$"))
+  (#any-of? @punctuation.delimiter ":" "@" "#"))
 
 ((directive_name) @keyword.directive
   (#match? @keyword.directive "^v-"))

--- a/languages/vue/highlights.scm
+++ b/languages/vue/highlights.scm
@@ -30,9 +30,10 @@
 
 (self_closing_tag) @tag
 
-"=" @punctuation.delimiter
-
-":" @punctuation.delimiter
+[
+  "="
+  ":"
+] @punctuation.delimiter
 
 [
   "<"


### PR DESCRIPTION
## Summary

This PR refines several token captures in `languages/vue/highlights.scm` so that themes can render Vue templates more consistently with how the HTML extension renders plain HTML, and with how Vue's official TextMate grammar (used by VSCode) scopes the same characters.

The motivation comes from a theme distinguishing operator vs. punctuation vs. constant vs. attribute name colors. Today the Vue grammar surfaces several characters under a category that doesn't match their syntactic role:

| Token | Before | After |
| --- | --- | --- |
| `=` between attribute and value | `@operator` | `@punctuation.delimiter` |
| Longhand directive separator `:` (e.g. `v-bind:click`) | inherits `@property` | `@punctuation.delimiter` |
| Shorthand directive prefixes `:`, `@`, `#` | `@keyword.directive` | `@punctuation.delimiter` |
| `directive_argument` (e.g. `click`, `class`, `default`) | `@constant` | `@attribute` |

Longhand directive names (`v-bind`, `v-on`, `v-if`, ...) remain `@keyword.directive`. Each change is its own commit with rationale.

## Visual Comparison
| Before | After |
|--------|--------|
| <img width="700" height="480" alt="image" src="https://github.com/user-attachments/assets/a8b7a542-c5fd-4370-a363-9f4e00edda2b" /> | <img width="700" height="480" alt="image" src="https://github.com/user-attachments/assets/cea58bd8-a7c8-4f38-994d-cc2e39a4c0e2" /> | 
| <img width="700" height="450" alt="image" src="https://github.com/user-attachments/assets/f46e163c-533b-479f-8d90-4c75248c0320" /> | <img width="700" height="450" alt="image" src="https://github.com/user-attachments/assets/bf6373ec-e320-493f-82f0-1735c11f6ba1" /> | 

## Reference: VSCode (Vue official TextMate grammar)

For comparison, the equivalent scopes in `vuejs/language-tools`'s [`extensions/vscode/syntaxes/vue.tmLanguage.json`](https://github.com/...) (pinned to commit `9e97191`):

- `=` in directive expression (quoted) → [`punctuation.separator.key-value.html.vue` (L1298)](https://github.com/vuejs/language-tools/blob/9e97191011802988649b4d4f4b1c0525165aec9b/extensions/vscode/syntaxes/vue.tmLanguage.json#L1298)
- `=` in directive expression (unquoted) → [`punctuation.separator.key-value.html.vue` (L1327)](https://github.com/vuejs/language-tools/blob/9e97191011802988649b4d4f4b1c0525165aec9b/extensions/vscode/syntaxes/vue.tmLanguage.json#L1327)
- Longhand `:` separator (`v-bind:click`) → [`punctuation.separator.key-value.html.vue` (L1228)](https://github.com/vuejs/language-tools/blob/9e97191011802988649b4d4f4b1c0525165aec9b/extensions/vscode/syntaxes/vue.tmLanguage.json#L1228)
- Shorthand `:` (v-bind) → [`punctuation.attribute-shorthand.bind.html.vue` (L1231)](https://github.com/vuejs/language-tools/blob/9e97191011802988649b4d4f4b1c0525165aec9b/extensions/vscode/syntaxes/vue.tmLanguage.json#L1231)
- Shorthand `@` (v-on) → [`punctuation.attribute-shorthand.event.html.vue` (L1234)](https://github.com/vuejs/language-tools/blob/9e97191011802988649b4d4f4b1c0525165aec9b/extensions/vscode/syntaxes/vue.tmLanguage.json#L1234)
- Shorthand `#` (v-slot) → [`punctuation.attribute-shorthand.slot.html.vue` (L1237)](https://github.com/vuejs/language-tools/blob/9e97191011802988649b4d4f4b1c0525165aec9b/extensions/vscode/syntaxes/vue.tmLanguage.json#L1237)
- Directive argument (e.g. `click`, `class`) → [`entity.other.attribute-name.html.vue` (L1254)](https://github.com/vuejs/language-tools/blob/9e97191011802988649b4d4f4b1c0525165aec9b/extensions/vscode/syntaxes/vue.tmLanguage.json#L1254)

Each shorthand prefix has its own dedicated punctuation scope in the TextMate grammar; since user themes typically style `punctuation.*` uniformly, treating them all as `@punctuation.delimiter` in the tree-sitter highlights captures the same intent.