### PR TITLE
Always inject the bundled `@vue/typescript-plugin`

### DIFF
--- a/src/vue.rs
+++ b/src/vue.rs
@@ -27,6 +27,10 @@ struct VueExtension {
     did_find_server: bool,
 }
 
+fn extension_install_dir() -> String {
+    env::current_dir().unwrap().to_string_lossy().to_string()
+}
+
 impl VueExtension {
     fn server_exists(&self) -> bool {
         fs::metadata(SERVER_PATH).is_ok_and(|stat| stat.is_file())
@@ -40,7 +44,7 @@ impl VueExtension {
         let server_exists = self.server_exists();
         if self.did_find_server && server_exists {
             self.install_typescript_if_needed(worktree)?;
-            self.install_ts_plugin_if_needed()?;
+            self.sync_ts_plugin();
             return Ok(SERVER_PATH.to_string());
         }
 
@@ -75,6 +79,7 @@ impl VueExtension {
         }
 
         self.install_typescript_if_needed(worktree)?;
+        self.sync_ts_plugin();
         self.did_find_server = true;
         Ok(SERVER_PATH.to_string())
     }
@@ -118,40 +123,32 @@ impl VueExtension {
         Ok(())
     }
 
-    fn install_ts_plugin_if_needed(&mut self) -> Result<()> {
-        let installed_plugin_version = zed::npm_package_installed_version(TS_PLUGIN_PACKAGE_NAME)?;
-        let latest_plugin_version = zed::npm_package_latest_version(TS_PLUGIN_PACKAGE_NAME)?;
+    fn sync_ts_plugin(&mut self) {
+        let server_version = match zed::npm_package_installed_version(PACKAGE_NAME) {
+            Ok(Some(version)) => version,
+            Ok(None) => {
+                println!("warning: could not determine installed {PACKAGE_NAME} version; skipping ts-plugin sync");
+                return;
+            }
+            Err(err) => {
+                println!("warning: could not query {PACKAGE_NAME} version: {err}; skipping ts-plugin sync");
+                return;
+            }
+        };
+        if let Err(err) = self.install_ts_plugin_if_needed(&server_version) {
+            println!("warning: failed to sync {TS_PLUGIN_PACKAGE_NAME}@{server_version}: {err}");
+        }
+    }
 
-        if installed_plugin_version.as_ref() != Some(&latest_plugin_version) {
-            println!("installing {TS_PLUGIN_PACKAGE_NAME}@{latest_plugin_version}");
-            zed::npm_install_package(TS_PLUGIN_PACKAGE_NAME, &latest_plugin_version)?;
+    fn install_ts_plugin_if_needed(&mut self, target_version: &str) -> Result<()> {
+        let installed_plugin_version = zed::npm_package_installed_version(TS_PLUGIN_PACKAGE_NAME)?;
+        if installed_plugin_version.as_deref() != Some(target_version) {
+            println!("installing {TS_PLUGIN_PACKAGE_NAME}@{target_version}");
+            zed::npm_install_package(TS_PLUGIN_PACKAGE_NAME, target_version)?;
         } else {
             println!("ts-plugin already installed");
         }
         Ok(())
-    }
-
-    fn get_ts_plugin_root_path(&self, worktree: &zed::Worktree) -> Result<Option<String>> {
-        let package_json = worktree.read_text_file("package.json")?;
-        let package_json: PackageJson = serde_json::from_str(&package_json)
-            .map_err(|err| format!("failed to parse package.json: {err}"))?;
-
-        let has_local_plugin = package_json
-            .dev_dependencies
-            .contains_key(TS_PLUGIN_PACKAGE_NAME)
-            || package_json
-                .dependencies
-                .contains_key(TS_PLUGIN_PACKAGE_NAME);
-
-        if has_local_plugin {
-            println!("Using local installation of {TS_PLUGIN_PACKAGE_NAME}");
-            return Ok(None);
-        }
-
-        println!("Using global installation of {TS_PLUGIN_PACKAGE_NAME}");
-        Ok(Some(
-            env::current_dir().unwrap().to_string_lossy().to_string(),
-        ))
     }
 }
 
@@ -218,13 +215,13 @@ impl zed::Extension for VueExtension {
         &mut self,
         _language_server_id: &zed::LanguageServerId,
         target_language_server_id: &zed::LanguageServerId,
-        worktree: &zed::Worktree,
+        _worktree: &zed::Worktree,
     ) -> Result<Option<serde_json::Value>> {
         match target_language_server_id.as_ref() {
             "typescript-language-server" => Ok(Some(serde_json::json!({
                 "plugins": [{
                     "name": "@vue/typescript-plugin",
-                    "location": self.get_ts_plugin_root_path(worktree)?.unwrap_or_else(|| worktree.root_path()),
+                    "location": extension_install_dir(),
                     "languages": ["typescript", "vue.js"],
                 }],
             }))),
@@ -236,7 +233,7 @@ impl zed::Extension for VueExtension {
         &mut self,
         _language_server_id: &zed::LanguageServerId,
         target_language_server_id: &zed::LanguageServerId,
-        worktree: &zed::Worktree,
+        _worktree: &zed::Worktree,
     ) -> Result<Option<serde_json::Value>> {
         match target_language_server_id.as_ref() {
             "vtsls" => Ok(Some(serde_json::json!({
@@ -244,7 +241,7 @@ impl zed::Extension for VueExtension {
                     "tsserver": {
                         "globalPlugins": [{
                             "name": "@vue/typescript-plugin",
-                            "location": self.get_ts_plugin_root_path(worktree)?.unwrap_or_else(|| worktree.root_path()),
+                            "location": extension_install_dir(),
                             "enableForWorkspaceTypeScriptVersions": true,
                             "languages": ["vue.js"],
                             "configNamespace": "typescript"


### PR DESCRIPTION
## What

Always inject the extension's own bundled `@vue/typescript-plugin` instead of reading the project's `package.json` to locate it. `get_ts_plugin_root_path` is removed and both injection hooks now point at the extension's install dir via `extension_install_dir()`. A new best-effort `sync_ts_plugin()` — called on first launch and in the cached path — installs the plugin at the same version as `@vue/language-server`; on failure it logs rather than propagating, so a plugin problem degrades TypeScript features instead of blocking the language server from starting. Net diff is `src/vue.rs` only.

This mirrors how the plugin is resolved elsewhere: the official VSCode Vue extension registers it via the `typescriptServerPlugins` contribution from its own bundle ([vuejs/language-tools → extensions/vscode/src/extension.ts](https://github.com/vuejs/language-tools/blob/master/extensions/vscode/src/extension.ts)), and the Zed Svelte extension always injects its bundled plugin and never reads the workspace `package.json` ([zed-extensions/svelte → src/svelte.rs](https://github.com/zed-extensions/svelte/blob/main/src/svelte.rs)).

## Why

**#76** — In a monorepo whose worktree root has no `package.json`, `get_ts_plugin_root_path` did `read_text_file("package.json")?`; the error propagated and aborted plugin injection, so the TS server never learned about `.vue` files and go-to-definition / hover / completions silently broke. Not reading `package.json` on the injection path fixes it by construction.

**#108** — The plugin was installed at its own independent latest version (could drift from `@vue/language-server`) and only in the cached path, never on first launch. `sync_ts_plugin()` pins it to the server version and installs it on first launch.

Behaviour change: a project that listed `@vue/typescript-plugin` in its own `package.json` now gets the bundled copy instead (as VSCode and the Svelte extension already do). Navigation/hover/completion are unaffected; only diagnostics could differ if a project pins a different Volar major.

Closes #76
Closes #108
(Likely also resolves #101, since the plugin is now present before the server starts.)

## Verified

`cargo fmt` / `clippy` / release build clean, and tested live in Zed as a dev extension against a monorepo with no root `package.json` — completions, hover, and go-to-definition all work.